### PR TITLE
[Enhancement]Add null support in WHERE Clause for VQL Builder

### DIFF
--- a/frontend/src/app/components/vql-editor/query-builder/QueryFilterRow.jsx
+++ b/frontend/src/app/components/vql-editor/query-builder/QueryFilterRow.jsx
@@ -69,12 +69,15 @@ export default function QueryFilterRow({
                                 onChange={(newValue) => handleSelectedFilterEdits(newValue, filterRowIndex, 'value')}
                             />
                         </Box>
-                        : <Input
-                            placeholder={operator.value === 'CONTAINS' ? `Enter comma-separated values (${fieldType})` : (fieldType) ? `Value (${fieldType})` : 'Value'}
-                            value={filter.value}
-                            onChange={(event) => handleSelectedFilterEdits(event.target.value, filterRowIndex, 'value')}
-                            {...InputStyle}
-                        />
+                        : <>
+                            { filter?.operator.value !== "IS NULL" && filter?.operator.value !== "IS NOT NULL" && 
+                            ( <Input 
+                                placeholder={operator.value === 'CONTAINS' ? `Enter comma-separated values (${fieldType})` : (fieldType) ? `Value (${fieldType})` : 'Value'}
+                                value={filter.value}
+                                onChange={(event) => handleSelectedFilterEdits(event.target.value, filterRowIndex, 'value')}
+                                {...InputStyle} 
+                            /> )}
+                        </>
                     }
                 </>
             }

--- a/frontend/src/app/components/vql-editor/query-builder/VqlDefinitions.js
+++ b/frontend/src/app/components/vql-editor/query-builder/VqlDefinitions.js
@@ -1,6 +1,6 @@
 export default function VqlDefinitions() {
 
-    const defaultOperators = ['=', '!=', '<', '>', '<=', '>=', 'CONTAINS', 'LIKE'];
+    const defaultOperators = ['=', '!=', '<', '>', '<=', '>=', 'CONTAINS', 'LIKE', 'IS NULL', 'IS NOT NULL'];
     const booleanValues = ['true', 'false'];
 
     const attachmentsQueryTarget = {

--- a/frontend/src/app/hooks/vql-editor/useQueryBuilder.js
+++ b/frontend/src/app/hooks/vql-editor/useQueryBuilder.js
@@ -325,6 +325,10 @@ export default function useQueryBuilder({ setCode }) {
                     }
 
                     whereClause += `(${filter?.field?.value} ${filter.operator.value} (${filterValue}))`
+                } else if (filter?.operator.value == "IS NULL") {
+                    whereClause += `(${filter?.field?.value} == null)`
+                } else if (filter?.operator.value == "IS NOT NULL") {
+                    whereClause += `(${filter?.field?.value} != null)`
                 } else {
                     if (filter?.field.fieldType === 'String' || filter?.field.fieldType === 'Date' || filter?.field.fieldType === 'DateTime' || filter?.field.fieldType === 'ID') {
                         // Wrap all String/Date/DateTime/ID values in a string
@@ -363,7 +367,25 @@ export default function useQueryBuilder({ setCode }) {
 
         if (selectedFilters?.length > 0) {
             selectedFilters.forEach((filter, index) => {
-                if (!filter?.field || !filter?.operator || !filter?.value) { canBuild = false; }
+                if (!filter?.field) {
+                    canBuild = false;
+                    return;
+                }
+
+                if (!filter?.operator) {
+                    canBuild = false;
+                    return;
+                }
+
+                if (filter?.operator.value == 'IS NULL' ||filter?.operator.value == 'IS NOT NULL') {
+                    canBuild = true;
+                    return;
+                }
+
+                if (!filter?.value) { 
+                    canBuild = false; 
+                    return;
+                }
             })
         }
 


### PR DESCRIPTION
#### Why 

Currently, in VQL Builder, we don't have null support for WHERE clauses (`!=null` and  `=null`).

When selecting the `=` or `!=` operation, all the input will be converted to a string, which means all we can get is `!='null'` and `='null'`.

#### Major change
This change add two operations for null. The reason I didn't modify the existing `=` and `!=` operators is that the user can still do `!='null'` after this change (if there's a use case for that)

#### Test

![not_null](https://github.com/user-attachments/assets/922bd95f-508f-4148-a2f6-31a294a0a54c)

![is_null](https://github.com/user-attachments/assets/891fe073-fe00-450f-810d-f709ed854bba)



